### PR TITLE
Drop the GitHub Streak badge from the profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,3 @@
   <source media="(prefers-color-scheme: light)" srcset="[github-snake.svg](https://raw.githubusercontent.com/timjacksonm/timjacksonm/snkoutput/github-snake.svg)" />
   <img alt="github-snake" src="github-snake.svg" />
 </picture>
-
----
-
-[![GitHub Streak](https://streak-stats.demolab.com?user=timjacksonm&exclude_days=Sun%2CSat)](https://git.io/streak-stats)


### PR DESCRIPTION
## Summary
- Removes the GitHub Streak Stats badge, which pulls from a shared public demo instance of a community project and intermittently fails to load
- The snake contribution graphic stays — it's hosted from this repo's own generated branch and has been reliable

## Test plan
- [ ] View the rendered README on GitHub to confirm the streak badge is gone and the snake graphic still renders