### PR TITLE
Rename the Life Simulation link label

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
                         <p>
                             <a class="link-out" href="https://play-life.netlify.app/gamehome" target="_blank"
                                 rel="noopener noreferrer">
-                                play-life.netlify.app
+                                try life here
                                 <svg class="icon icon--arrow" viewBox="0 0 24 24" width="1em" height="1em" fill="none"
                                     stroke="currentColor" stroke-width="2" stroke-linecap="round"
                                     stroke-linejoin="round" aria-hidden="true" focusable="false">


### PR DESCRIPTION
## Summary
- Link text was the raw domain (play-life.netlify.app), which read a little oddly
- Changed to "try life here" — avoids "play"/game framing since it's a simulation, not a game, while keeping the whole phrase clickable (not just "here") so the link stays descriptive on its own

## Test plan
- [ ] View the Projects section and confirm the link reads "try life here" and still opens the Life Simulation app