### PR TITLE
Update profile README intro and simplify Get in Touch to LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-✨ Welcome! You can find my website [here](https://www.timjacksonm.com/)
+Full-Stack Software Engineer. More about me at [timjacksonm.com](https://www.timjacksonm.com/).
 
 ---
 

--- a/index.css
+++ b/index.css
@@ -481,24 +481,9 @@ h1 {
     color: var(--muted);
 }
 
-.contact {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.625rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
-
 @media (min-width: 40em) {
     :root {
         --band-space: 4rem;
-    }
-
-    .contact {
-        flex-direction: row;
-        gap: 2rem;
     }
 
     .invader--crab {

--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
             <h2 class="label eyebrow" id="contact">Get in Touch</h2>
             <div class="band__body">
                 <p>
-                    Reach out to me on
+                    Any questions or inquiries? Feel free to reach out to me on
                     <a class="link-out" href="https://www.linkedin.com/in/timjacksonm/" target="_blank"
                         rel="noopener noreferrer">
                         LinkedIn

--- a/index.html
+++ b/index.html
@@ -227,31 +227,18 @@
         <footer class="band" aria-labelledby="contact">
             <h2 class="label eyebrow" id="contact">Get in Touch</h2>
             <div class="band__body">
-                <p>Any questions or inquiries? Feel free to reach out on:</p>
-                <ul class="contact">
-                    <li>
-                        <a class="link-out" href="https://www.linkedin.com/in/timjacksonm/" target="_blank"
-                            rel="noopener noreferrer">
-                            <svg class="icon" viewBox="0 0 448 512" width="1em" height="1em" fill="currentColor"
-                                aria-hidden="true" focusable="false">
-                                <path
-                                    d="M100.28 448H7.4V148.9h92.88zM53.79 108.1C24.09 108.1 0 83.5 0 53.8a53.79 53.79 0 0 1 107.58 0c0 29.7-24.1 54.3-53.79 54.3zM447.9 448h-92.68V302.4c0-34.7-12.4-58.4-43.4-58.4-23.7 0-37.8 15.9-44 31.3-2.3 5.5-2.9 13.2-2.9 20.9V448h-92.8s1.2-241.1 0-266.1h92.8v37.7c12.3-19 34.4-46.2 83.7-46.2 61.1 0 106.9 39.9 106.9 125.7z" />
-                            </svg>
-                            LinkedIn
-                        </a>
-                    </li>
-                    <li>
-                        <a class="link-out" href="https://github.com/timjacksonm" target="_blank"
-                            rel="noopener noreferrer">
-                            <svg class="icon" viewBox="0 0 496 512" width="1em" height="1em" fill="currentColor"
-                                aria-hidden="true" focusable="false">
-                                <path
-                                    d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8z" />
-                            </svg>
-                            GitHub
-                        </a>
-                    </li>
-                </ul>
+                <p>
+                    Reach out to me on
+                    <a class="link-out" href="https://www.linkedin.com/in/timjacksonm/" target="_blank"
+                        rel="noopener noreferrer">
+                        LinkedIn
+                        <svg class="icon icon--arrow" viewBox="0 0 24 24" width="1em" height="1em" fill="none"
+                            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                            aria-hidden="true" focusable="false">
+                            <path d="M7 17 17 7M9 7h8v8" />
+                        </svg>
+                    </a>.
+                </p>
             </div>
         </footer>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the placeholder README intro ("Welcome! You can find my website here") with a real name/role summary and the site link — no job-search status line, so it won't go stale
- Simplifies the site's "Get in Touch" section to LinkedIn only, since GitHub isn't a channel people can message on (it's still linked from the masthead); collapsed the two-item icon list into a single inline link and dropped the now-unused `.contact` CSS

## Test plan
- [ ] View the rendered README on GitHub to confirm the new intro line reads correctly
- [ ] View the Get in Touch section on the site and confirm it shows only the LinkedIn link and reads naturally